### PR TITLE
Enhanced for forms.py with required hidden fields

### DIFF
--- a/telegram_django_bot/forms.py
+++ b/telegram_django_bot/forms.py
@@ -84,7 +84,7 @@ class BaseTelegramForm(BaseForm):
         super().__init__(data, files, initial=initial)
         # self.error_class = TelegaErrorList
 
-        self.fields, self.next_field = self._init_helper_fields_detection(data)
+        self.next_field = self._init_helper_fields_detection(data)[1]
 
     def save(self, commit=True):
         """ save temp data to user data"""
@@ -113,6 +113,9 @@ class BaseTelegramForm(BaseForm):
         self._clean_fields()
         self._clean_form()
         self._post_clean()
+
+    def is_valid(self):
+        return self.is_bound
 
 
 class BaseTelegramModelForm(BaseTelegramForm, BaseModelForm):
@@ -150,7 +153,7 @@ class BaseTelegramModelForm(BaseTelegramForm, BaseModelForm):
         # self.error_class = TelegaErrorList
 
         self.next_field = None
-        self.fields, self.next_field = self._init_helper_fields_detection(data)
+        self.next_field = self._init_helper_fields_detection(data)[1]
 
     def save(self, commit=True, is_completed=True):
         """


### PR DESCRIPTION
Avoid overwrite form.fields and form.is_valid() overriden for no error check. This allow set a required field with HiddenInput widget class. Set the value of a required hidden field can be done overriding the constructor as like next example:


```
from django.forms import ALL_FIELDS, HiddenInput
from telegram_django_bot import forms as td_forms

class CustomModelForm(td_forms.TelegramModelForm):
    def __init__(self, *args, **kargs):
        if 'client' not in kargs['data'].keys():
            kargs['data'].update({'client': kargs['user'].pk})
        super().__init__(*args, **kargs)

    class Meta:
        model = CustomModel
        fields = ALL_FIELDS
        widgets = {
            'client': HiddenInput(),
        }
```